### PR TITLE
Fix tools/disasm & Add kernel-name argument in turingas

### DIFF
--- a/tools/disasm.py
+++ b/tools/disasm.py
@@ -39,7 +39,7 @@ def processSassLines(fline, sline, labels):
     target = int(BSSY_RE.match(asm).group(2), 16)
     if target not in labels:
       labels[target] = len(labels)
-
+  return ctrl, asm
 
 def extract(file_path, fun):
   if fun == None:

--- a/turingas/main.py
+++ b/turingas/main.py
@@ -7,6 +7,7 @@ def main():
   parser.add_argument('-i', '--input', help='input asm file', dest='input_asm', required=True, metavar='FILE')
   parser.add_argument('-o', '--output', help='output cubin file', dest='output_cubin', required=True, metavar='FILE')
   parser.add_argument('-inc', '--include', help='include files', nargs='+')
+  parser.add_argument('-name', '--kernel-name', help='kernel name', dest='kernel_name', default='kern', type=str)
   parser.add_argument('-arch', dest='arch', default=75, type=int, choices=[70, 75, 80, 86])
   args = parser.parse_args()
 
@@ -28,7 +29,7 @@ def main():
 
   # Write out cubin file
   cubin = Cubin(arch=args.arch)
-  cubin.add_kernel(kernel, b'kern', params, consts) 
+  cubin.add_kernel(kernel, args.kernel_name.encode(), params, consts) 
   cubin.Write(args.output_cubin)
 
 


### PR DESCRIPTION
1. fix missing return statement for processSassLines in disasm
2. add kernel-name argument `-name` support in turingas